### PR TITLE
[JENKINS-9263]  Downstream Build View does not recognize parameterized build trigger 

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewRunListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewRunListener.java
@@ -69,8 +69,6 @@ public final class DownstreamBuildViewRunListener extends RunListener<AbstractBu
     @Override
     public void onCompleted(AbstractBuild r,TaskListener listener) {
     	build = r;
-    	final DownstreamBuildViewAction downstreamBuildViewAction = new DownstreamBuildViewAction(r);
-        r.addAction(downstreamBuildViewAction);
         super.onFinalized(r);
         save();
     	

--- a/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewUpdateListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewUpdateListener.java
@@ -69,6 +69,9 @@ public final class DownstreamBuildViewUpdateListener extends RunListener<Abstrac
     @Override
     public void onStarted(AbstractBuild r,TaskListener listener) {
     	//build = r;
+        final DownstreamBuildViewAction downstreamBuildViewAction = new DownstreamBuildViewAction(r);
+        r.addAction(downstreamBuildViewAction);
+
     	CauseAction ca = r.getAction(CauseAction.class);
 
 


### PR DESCRIPTION
Related to https://issues.jenkins-ci.org/browse/JENKINS-9263

Anything preventing us adding DownstreamBuildViewAction for a build object already at the beginning of a build? This way we can add builds triggered within a buildstep as a downstream build to the action. I've tested this to work when using "Parameterized trigger" plugin to trigger builds within a buildstep.
