### PR TITLE
fix NPE when launching downstream build using promotion action

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewUpdateListener.java
+++ b/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewUpdateListener.java
@@ -82,7 +82,10 @@ public final class DownstreamBuildViewUpdateListener extends RunListener<Abstrac
     			String upProjectName = upcause.getUpstreamProject();
     			int buildNumber = upcause.getUpstreamBuild();
     			AbstractProject project = Hudson.getInstance().getItemByFullName(upProjectName, AbstractProject.class);
+				// This can be null if this project was started by a non-project (ie, promotion action)
+				if (project == null) continue;
     			AbstractBuild upBuild = (AbstractBuild)project.getBuildByNumber(buildNumber);
+				if (upBuild == null) continue;
     			build = upBuild;
     			for (DownstreamBuildViewAction action : upBuild.getActions(DownstreamBuildViewAction.class)) {
     				action.addDownstreamBuilds(r.getProject().getName(),r.getNumber());


### PR DESCRIPTION
I set up a promotion that contained an action to trigger a downstream build. Upon running the promotion I received 

```
java.lang.NullPointerException
    at org.jvnet.hudson.plugins.DownstreamBuildViewUpdateListener.onStarted(DownstreamBuildViewUpdateListener.java:85)
    at org.jvnet.hudson.plugins.DownstreamBuildViewUpdateListener.onStarted(DownstreamBuildViewUpdateListener.java:46)
    at hudson.model.listeners.RunListener.fireStarted(RunListener.java:188)
    at hudson.model.Run.run(Run.java:1429)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:239)
```

in the console output for the triggered job, which failed the build immediately. This pull request is a simple null check to avoid this from happening when a non-project triggers a downstream job.
