### PR TITLE
Don't animate grey balls for non-existent or not-running downstream builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.3</version>
+    <version>1.565.3</version>
   </parent>
 
   <groupId>org.jvnet.hudson.plugins</groupId>
@@ -63,4 +63,12 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.10</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.565.3</version>
+    <version>1.509.3</version>
   </parent>
 
   <groupId>org.jvnet.hudson.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,4 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.10</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/DownstreamBuildViewAction.java
@@ -155,10 +155,12 @@ public class DownstreamBuildViewAction extends AbstractDownstreamBuildViewAction
         }
 
         public String getImageUrl() {
-        	if(run == null ){
-        		initilize();
-        	}
-        	if (run == null || run.isBuilding()) {
+            if (run == null) {
+                initilize();
+            }
+            if (run == null) {
+                return BallColor.GREY.getImage();
+            } else if (run.isBuilding()) {
                 return BallColor.GREY.anime().getImage();
             } else {
                 return run.getResult().color.getImage();


### PR DESCRIPTION
Currently, unbuilt downstream jobs will show as a blinking grey ball, regardless of whether or not those jobs have runs that are actually queued or running. This change fixes that by only showing a blinking ball if the downstream run exists and is running, otherwise, a static grey ball will be shown instead. This is important since downstream builds may not always be started for a variety of reasons.

This change is provided as an alternative to #8, which adds an option to completely disable the animations regardless of the actual downstream build state.

Closes #8 